### PR TITLE
Update dune-project with dependencies.

### DIFF
--- a/dune-project
+++ b/dune-project
@@ -20,7 +20,24 @@
  (allow_empty)
  (synopsis "A short synopsis")
  (description "A longer description")
- (depends ocaml dune)
+ (depends 
+   ocaml 
+   dune
+   lwt
+   dream
+   cmdliner
+   caqti-driver-sqlite3
+   argon2
+   csvfields
+   ppx_csv_conv
+   re
+   bonsai
+   graphql_ppx
+   ppx_yojson_conv_lib
+   jingoo
+   ppx_yojson_conv
+   cohttp-lwt-jsoo 
+ )
  (tags
   (topics "to describe" your project)))
 

--- a/nittany_market.opam
+++ b/nittany_market.opam
@@ -12,6 +12,20 @@ bug-reports: "https://github.com/username/reponame/issues"
 depends: [
   "ocaml"
   "dune" {>= "3.0"}
+  "lwt"
+  "dream"
+  "cmdliner"
+  "caqti-driver-sqlite3"
+  "argon2"
+  "csvfields"
+  "ppx_csv_conv"
+  "re"
+  "bonsai"
+  "graphql_ppx"
+  "ppx_yojson_conv_lib"
+  "jingoo"
+  "ppx_yojson_conv"
+  "cohttp-lwt-jsoo"
   "odoc" {with-doc}
 ]
 build: [


### PR DESCRIPTION
Adds the dependencies used in the dune file into dune-project. The version bounds could be tighter but this works for me.

Now when you create a switch as
``` 
opam switch create . 4.13.1 --deps-only --with-test
```
or install the dependencies based off the opam files as
```
opam install . --with-test --yes --deps-only 
```
and you end up with a working set of packages. 

Thanks for the great writeup and example code. I have learnt a lot from looking at how the GraphQL loader works and how that data gets used in Bonsai.